### PR TITLE
Handle optional succeeding three letter currency codes

### DIFF
--- a/kswatch.py
+++ b/kswatch.py
@@ -75,8 +75,10 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
             return
 
         if self.in_li_block and tag == 'input':
+            # remove preceding currency sign and optional succeeding currency code
+            amount = attrs['title'].split()[0][1:]
             # Convert the value into a float
-            self.value = float(attrs['title'][1:].replace(',', ''))
+            self.value = float(amount.replace(',', ''))
             self.ident = attrs['id']
 
         if self.in_li_block and tag == 'p':


### PR DESCRIPTION
The relevant HTML of the omate pledge page (https://www.kickstarter.com/projects/omate/omate-truesmart-water-resistant-standalone-smartwa/pledge/new) looks like:

```
<input alt="$10.00 USD" class="radio" id="backing_backer_reward_id_1910694" 
name="backing[backer_reward_id]" title="$10.00 USD" type="radio" value="1910694" />
```

which results in 

```
Traceback (most recent call last):
  File "kswatch.py", line 152, in <module>
    rewards = ks.process(url)
  File "kswatch.py", line 65, in process
    self.feed(html)   # feed() starts the HTMLParser parsing
  File "C:\Python27\lib\HTMLParser.py", line 114, in feed
    self.goahead(0)
  File "C:\Python27\lib\HTMLParser.py", line 158, in goahead
    k = self.parse_starttag(i)
  File "C:\Python27\lib\HTMLParser.py", line 322, in parse_starttag
    self.handle_startendtag(tag, attrs)
  File "C:\Python27\lib\HTMLParser.py", line 404, in handle_startendtag
    self.handle_starttag(tag, attrs)
  File "kswatch.py", line 79, in handle_starttag
    self.value = float(attrs['title'][1:].replace(',', ''))
ValueError: invalid literal for float(): 10.00 USD
```

This pull request also removes the succeeding three letter monetary code.
